### PR TITLE
Comment unmask lines so cleanup script works with -f

### DIFF
--- a/scripts/tatt
+++ b/scripts/tatt
@@ -194,12 +194,12 @@ if not myJob.packageList==None:
         else:
             unmaskfile.write(p.packageString())
             if myJob.type=="stable":
-                unmaskfile.write("\n")
+                pass
             elif myJob.type=="keyword":
-                unmaskfile.write(" ** \n")
+                unmaskfile.write(" ** ")
             else:
                 print ("Uh Oh, no job.type? Tell tomka@gentoo.org to fix this!")
-                unmaskfile.write("\n")
+            unmaskfile.write("  # Job " + myJob.name + "\n")
             print ("Unmasked " + p.packageString()+ " in "+config['unmaskfile'])
     unmaskfile.close()
     ## Write the scripts


### PR DESCRIPTION
Decorates the unmask lines with the job name so that the cleanup script will remove the lines even if the job name and package name do not mask e.g. when using the -f parameter.